### PR TITLE
Parent argv

### DIFF
--- a/index.js
+++ b/index.js
@@ -162,7 +162,9 @@ util.spawn = function(opts, done) {
   var cmd, args, parentArgs;
   var pathSeparatorRe = /[\\\/]/g;
   // List of args that are followed by a corresponding value
-  var argsWithValues = ['--base', '--gruntfile'];
+  var argsWithValues = ['--gruntfile'];
+  // List of arguments that are not to be passed to the child process
+  var argBlacklist = ['--base', '-b'];
   // Flag to allow values associated with args in argsWithValues to pass through
   var allowNextArg = false;
   if (opts.grunt) {
@@ -173,7 +175,9 @@ util.spawn = function(opts, done) {
     parentArgs = parentArgs.filter(
         function removeTasksFromArgs (arg) {
             var allow = false;
-            if (allowNextArg || arg.indexOf('-') === 0) {
+            if (
+              allowNextArg ||
+              (argBlacklist.indexOf(arg) === -1 && arg.indexOf('-') === 0)) {
                 allow = true;
             }
             // Determine if next arg should be allowed

--- a/index.js
+++ b/index.js
@@ -161,10 +161,8 @@ util.spawn = function(opts, done) {
 
   var cmd, args, parentArgs;
   var pathSeparatorRe = /[\\\/]/g;
-  // List of args to avoid passing to child process
-  var argBlacklist = ['--gruntfile'];
   // List of args that are followed by a corresponding value
-  var argsWithValues = ['--base'];
+  var argsWithValues = ['--base', '--gruntfile'];
   // Flag to allow values associated with args in argsWithValues to pass through
   var allowNextArg = false;
   if (opts.grunt) {
@@ -175,10 +173,10 @@ util.spawn = function(opts, done) {
     parentArgs = parentArgs.filter(
         function removeTasksFromArgs (arg) {
             var allow = false;
-            if (allowNextArg ||
-                (arg.indexOf('-') === 0 && argBlacklist.indexOf(arg) === -1)) {
+            if (allowNextArg || arg.indexOf('-') === 0) {
                 allow = true;
             }
+            // Determine if next arg should be allowed
             allowNextArg = (argsWithValues.indexOf(arg) !== -1);
             return allow;
         });

--- a/index.js
+++ b/index.js
@@ -163,7 +163,7 @@ util.spawn = function(opts, done) {
   var pathSeparatorRe = /[\\\/]/g;
   if (opts.grunt) {
     cmd = process.execPath;
-    args = process.execArgv.concat(process.argv[1], opts.args);
+    args = process.execArgv.concat(process.argv[1], opts.args, process.argv.slice(3));
   } else {
     // On Windows, child_process.spawn will only file .exe files in the PATH,
     // not other executable types (grunt issue #155).

--- a/index.js
+++ b/index.js
@@ -174,8 +174,13 @@ util.spawn = function(opts, done) {
     // Remove any blacklisted args, and any that are not flags
     parentArgs = parentArgs.filter(
         function removeTasksFromArgs (arg) {
+            var allow = false;
+            if (allowNextArg ||
+                (arg.indexOf('-') === 0 && argBlacklist.indexOf(arg) === -1)) {
+                allow = true;
+            }
             allowNextArg = (argsWithValues.indexOf(arg) !== -1);
-            return arg.indexOf('-') === 0 && (argBlacklist.indexOf(arg) === -1);
+            return allow;
         });
     args = process.execArgv.concat(process.argv[1], parentArgs, opts.args);
   } else {

--- a/index.js
+++ b/index.js
@@ -159,11 +159,25 @@ util.spawn = function(opts, done) {
     done(code === 0 || 'fallback' in opts ? null : new Error(stderr), result, code);
   };
 
-  var cmd, args;
+  var cmd, args, parentArgs;
   var pathSeparatorRe = /[\\\/]/g;
+  // List of args to avoid passing to child process
+  var argBlacklist = ['--gruntfile'];
+  // List of args that are followed by a corresponding value
+  var argsWithValues = ['--base'];
+  // Flag to allow values associated with args in argsWithValues to pass through
+  var allowNextArg = false;
   if (opts.grunt) {
     cmd = process.execPath;
-    args = process.execArgv.concat(process.argv[1], opts.args, process.argv.slice(3));
+    // Capture current process arguments, excluding node and grunt (first two args)
+    parentArgs = process.argv.slice(2);
+    // Remove any blacklisted args, and any that are not flags
+    parentArgs = parentArgs.filter(
+        function removeTasksFromArgs (arg) {
+            allowNextArg = (argsWithValues.indexOf(arg) !== -1);
+            return arg.indexOf('-') === 0 && (argBlacklist.indexOf(arg) === -1);
+        });
+    args = process.execArgv.concat(process.argv[1], parentArgs, opts.args);
   } else {
     // On Windows, child_process.spawn will only file .exe files in the PATH,
     // not other executable types (grunt issue #155).

--- a/test/fixtures/Gruntfile-argv-child.js
+++ b/test/fixtures/Gruntfile-argv-child.js
@@ -1,0 +1,7 @@
+module.exports = function(grunt) {
+
+  grunt.registerTask('default', function(text) {
+    console.log('OUTPUT: ' + process.argv.slice(2).join(' '));
+  });
+
+};

--- a/test/fixtures/Gruntfile-argv.js
+++ b/test/fixtures/Gruntfile-argv.js
@@ -8,6 +8,10 @@ module.exports = function(grunt) {
       grunt: true,
       args: ['--gruntfile', 'Gruntfile-argv-child.js'],
     }, function(err, result, code) {
+      if (err || code !== 0) {
+        console.error(result.stderr);
+        throw new Error('Error in spawned grandchild process');
+      }
       var matches = result.stdout.match(/^(OUTPUT: .*)/m);
       console.log(matches ? matches[1] : '');
       done();

--- a/test/fixtures/Gruntfile-argv.js
+++ b/test/fixtures/Gruntfile-argv.js
@@ -1,0 +1,17 @@
+module.exports = function(grunt) {
+
+  var util = require('../../');
+
+  grunt.registerTask('default', function(text) {
+    var done = this.async();
+    util.spawn({
+      grunt: true,
+      args: ['--gruntfile', 'Gruntfile-argv-child.js'],
+    }, function(err, result, code) {
+      var matches = result.stdout.match(/^(OUTPUT: .*)/m);
+      console.log(matches ? matches[1] : '');
+      done();
+    });
+  });
+
+};

--- a/test/index.js
+++ b/test/index.js
@@ -267,8 +267,6 @@ exports['util.spawn'] = {
       cmd: process.execPath,
       args: [ process.argv[1], '--gruntfile', 'test/fixtures/Gruntfile-argv.js', '--no-write'],
     }, function(err, result, code) {
-      //test.equals(err, null, 'spawning a child and grandchild with --gruntfile fails');
-      //test.equals(code, 0, 'spawning a child and grandchild with --gruntfile fails');
       test.equals(err, null);
       test.equals(code, 0);
       test.ok(/^OUTPUT: --no-write/m.test(result.stdout), 'spawning child and grandchild with --gruntfile fails.');

--- a/test/index.js
+++ b/test/index.js
@@ -253,11 +253,11 @@ exports['util.spawn'] = {
     }, function(err, result, code) {
       test.equals(err, null);
       test.equals(code, 0);
-      test.ok(/^OUTPUT: --no-write/m.test(result.stdout), 'stdout should contain passed through process.argv.');
+      test.ok(/^OUTPUT: .*--no-write/m.test(result.stdout), 'stdout should contain passed through process.argv.');
       test.done();
     });
   },
-  'grunt does not pass --gruntfile to child': function(test) {
+  'grunt does pass --gruntfile to child': function(test) {
     // Note: this is exactly the same test as the one above
     // All of the grunt-spawn tests are also testing this condition, as they will fail if --gruntfile is passed
     // It is duplicated here to be sure that future changes do not 
@@ -269,13 +269,13 @@ exports['util.spawn'] = {
     }, function(err, result, code) {
       test.equals(err, null);
       test.equals(code, 0);
-      test.ok(/^OUTPUT: --no-write/m.test(result.stdout), 'spawning child and grandchild with --gruntfile fails.');
+      test.ok(/^OUTPUT: --gruntfile test\/fixtures\/Gruntfile-argv.js/m.test(result.stdout), 'stdout should contain passed-through gruntfile path');
       test.done();
     });
   },
   'grunt passes parent --base arg and val': function(test) {
     var testBase = process.cwd() + '/test/fixtures';
-    var testBaseRegex = new RegExp('^OUTPUT: --base ' + testBase, 'm');
+    var testBaseRegex = new RegExp('^OUTPUT: .*--base ' + testBase, 'm');
     test.expect(3);
     util.spawn({
       cmd: process.execPath,

--- a/test/index.js
+++ b/test/index.js
@@ -245,6 +245,50 @@ exports['util.spawn'] = {
       test.done();
     });
   },
+  'grunt passes parent argv': function(test) {
+    test.expect(3);
+    util.spawn({
+      cmd: process.execPath,
+      args: [ process.argv[1], '--gruntfile', 'test/fixtures/Gruntfile-argv.js', '--no-write'],
+    }, function(err, result, code) {
+      test.equals(err, null);
+      test.equals(code, 0);
+      test.ok(/^OUTPUT: --no-write/m.test(result.stdout), 'stdout should contain passed through process.argv.');
+      test.done();
+    });
+  },
+  'grunt does not pass --gruntfile to child': function(test) {
+    // Note: this is exactly the same test as the one above
+    // All of the grunt-spawn tests are also testing this condition, as they will fail if --gruntfile is passed
+    // It is duplicated here to be sure that future changes do not 
+    // neglect to test this condition.
+    test.expect(3);
+    util.spawn({
+      cmd: process.execPath,
+      args: [ process.argv[1], '--gruntfile', 'test/fixtures/Gruntfile-argv.js', '--no-write'],
+    }, function(err, result, code) {
+      //test.equals(err, null, 'spawning a child and grandchild with --gruntfile fails');
+      //test.equals(code, 0, 'spawning a child and grandchild with --gruntfile fails');
+      test.equals(err, null);
+      test.equals(code, 0);
+      test.ok(/^OUTPUT: --no-write/m.test(result.stdout), 'spawning child and grandchild with --gruntfile fails.');
+      test.done();
+    });
+  },
+  'grunt passes parent --base arg and val': function(test) {
+    var testBase = process.cwd() + '/test/fixtures';
+    var testBaseRegex = new RegExp('^OUTPUT: --base ' + testBase, 'm');
+    test.expect(3);
+    util.spawn({
+      cmd: process.execPath,
+      args: [ process.argv[1], '--gruntfile', 'test/fixtures/Gruntfile-argv.js', '--base', process.cwd() + '/test/fixtures'],
+    }, function(err, result, code) {
+      test.equals(err, null);
+      test.equals(code, 0);
+      test.ok(testBaseRegex.test(result.stdout), 'stdout should contain --base argument and value');
+      test.done();
+    });
+  },
   'grunt result.toString() with error': function(test) {
     // grunt.log.error uses standard out, to be fixed in 0.5.
     test.expect(4);

--- a/test/index.js
+++ b/test/index.js
@@ -273,17 +273,17 @@ exports['util.spawn'] = {
       test.done();
     });
   },
-  'grunt passes parent --base arg and val': function(test) {
-    var testBase = process.cwd() + '/test/fixtures';
+  'grunt should not pass --base arg and val': function(test) {
+    var testBase = 'test/fixtures';
     var testBaseRegex = new RegExp('^OUTPUT: .*--base ' + testBase, 'm');
     test.expect(3);
     util.spawn({
       cmd: process.execPath,
-      args: [ process.argv[1], '--gruntfile', 'test/fixtures/Gruntfile-argv.js', '--base', process.cwd() + '/test/fixtures'],
+      args: [ process.argv[1], '--gruntfile', 'test/fixtures/Gruntfile-argv.js', '--base', testBase],
     }, function(err, result, code) {
-      test.equals(err, null);
-      test.equals(code, 0);
-      test.ok(testBaseRegex.test(result.stdout), 'stdout should contain --base argument and value');
+      test.equals(err, null, 'multi-generational grunt spawn with relative base path failed'); 
+      test.equals(code, 0, 'multi-generational grunt spawn with relative base path failed');
+      test.ok(!testBaseRegex.test(result.stdout), 'stdout should NOT contain --base argument and value');
       test.done();
     });
   },


### PR DESCRIPTION
More background can be found at the original issue in the grunt repository: https://github.com/gruntjs/grunt/issues/1172

This patch turned out to be far less simple than I originally thought, but it is working well now, thanks to unit-testing!!
# Motivation:

When spawning a child process using `grunt.util.spawn` with the options `grunt: true`, the child process should inherit any command line flags passed to the parent process. Most importantly, the `--debug` and `--no-write` flags should always be passed to any children to prevent unwanted behavior. 
# Original solution:

It seemed so simple at first:

I modified grunt-legacy-utils/index.js as follows to ensure that the parent's CLI args were passed to the child:

``` js
- args = process.execArgv.concat(process.argv[1], opts.args);
+ args = process.execArgv.concat(process.argv[1], opts.args, process.argv.slice(3));
```
## Problem(s) with original solution:
1. Assumes that the _task_ argument is at position two of the process.argv array. This is wrong because the task may not even be in the arguments, and if it is, there is no guarantee that it will be the third element in the array.
2. Does not account for `--gruntfile path/to/gruntfile`: luckily, this was a heavily used paradigm in the unit tests, and I caught this problem when the tests that use `--gruntfile` failed. The reason that `--gruntfile` causes failures with the original solution is that the `--gruntfile` argument was the third argument in the args array, and was therefore being stripped. As a result, the gruntfile path was being interpreted as a task name, which was undefined. 
3. Does not account for relative `--base` paths. For instance, if a parent process is invoked from `/var/www` with `grunt default --base path/to/somewhere`, then the child process will attempt to calculate it's base as `/var/www/path/to/somewhere/path/to/somewhere`, which is probably not the user's intention.
# New Solution:

Instead of simply chopping off the first three arguments, we now need to filter them to remove the task name(s). This can be accomplished by removing any arguments that do not start with a `-`. 

Since filepaths do not start with a `-`, the will be stripped from the arguments during filtering. This is a problem when it comes to the file paths specified after the `--gruntfile` arguments, which we want to preserve (or at least I assume that we do). To solve this problem, I created a whitelist of arguments whose _next argument_ should always be allowed to stay. This allows the argument immediately following a `--gruntfile` argument to remain in the args list even if it does not start with a `-`. 

To address the issue of relative `--base` paths, I implemented a blacklist. Any arguments on the blacklist will be stripped during the filtering process. Since the file path associated with the blacklisted `--base` argument probably does not start with a `-`, it will be removed as well with no further logic required. There is no need to pass the `--base` argument to the child process, as it will be spawned from the parent's `base path` by default. 

**If a process invoked with a `--gruntfile` argument spawns a child, and provides different `--base` or `gruntfile` arguments to the `spawn` method, then the new arguments will override the parent's.** This is because the parent's arguments are inserted in the `args` array before the `opts.args` arguments are, and thus any arguments ins `opts.args` will override the parent's arguments. 
# Testing

I've added three tests to ensure that this feature is working properly:
- Test to be sure that a `--no-write` flag is passed automatically from a parent to a child grunt process.
- Test to be sure that the `--gruntfile` flag and its associated value are passed to the child process.
- Test to be sure that the `--base` flag and its associated value are passed to the child process.
# Conclusion

This proved to be more complicated than I originally anticipated. I hope that there are not any more _gotchas_ or use-cases that this change would cause problems with. An alternative, simpler solution would be to only pass specific arguments from parent to child. For example: only pass `--debug`, `--verbose` and `--no-write`, as those are the most likely to cause irreversible problems if they are not passed. Failing to pass the other flags may cause a child process to fail or stop, however, the developer can manually add any needed flags to the `opts.args` as needed. 

I eagerly await your review.
