### PR TITLE
Updates version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 language: node_js
 node_js:
-  - "0.8"
-  - "0.10"
-  - "0.11"
+  - "0.12"
+  - "5.0"
+  - "stable"
 before_script:
   - npm install -g grunt-cli
 matrix:
   fast_finish: true
-  allow_failures:
-    - node_js: "0.11"
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
   - "0.12"
-  - "5.0"
-  - "stable"
+  - "4"
+  - "5"
 before_script:
   - npm install -g grunt-cli
 matrix:

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "hooker": "~0.2.3",
     "async": "~0.1.22",
-    "lodash": "~0.9.2",
+    "lodash": "~3.0.0",
     "exit": "~0.1.1",
     "underscore.string": "~2.2.1",
     "getobject": "~0.1.0",


### PR DESCRIPTION
Even if this is deprecated, it's still included by grunt, so bumping up lodash version is a good idea. Relates to gruntjs/grunt-legacy-util#6 and gruntjs/grunt-legacy-util#8 except it updates `.travis.yml` too to pass tests.