### PR TITLE
Use NVM NodeJS aliases for NodeJS 4.x.x and 5.x.x branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,8 @@ language: node_js
 node_js:
   - "0.10"
   - "0.12"
-  - "4.0"
-  - "4.1"
-  - "4.2"
-  - "5.5"
+  - "4"
+  - "5"
   - "iojs"
 before_install:
   - npm install -g npm

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ language: node_js
 node_js:
   - "0.10"
   - "0.12"
-  - "4"
+  - "4.0"
+  - "4.1"
+  - "4.2"
   - "5"
   - "iojs"
 before_install:


### PR DESCRIPTION
See https://github.com/gruntjs/grunt-legacy-util/pull/9#issuecomment-173440880