### PR TITLE
Update to lodash@^4.3.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "exit": "~0.1.1",
     "getobject": "~0.1.0",
     "hooker": "~0.2.3",
-    "lodash": "~3.10.1",
+    "lodash": "^4.3.0",
     "underscore.string": "~3.2.3",
     "which": "~1.2.1"
   },


### PR DESCRIPTION
I noticed in [the grunt 1.0.0-rc release notes](https://github.com/gruntjs/grunt/pull/1457/files) that you all are using lodash v3.10.1.
I scanned grunt and didn't see any immediate red flags that would prevent ^4.0.0 so I bumped it.

Let me know if there are issues.