### PR TITLE
Create our own copy of lodash to avoid underscore.string polluting outside instances

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@ language: node_js
 node_js:
   - "0.10"
   - "0.12"
-  - "4.0"
-  - "4.1"
-  - "4.2"
+  - "4"
   - "5"
-  - "iojs"
+  - "6"
+  - "7"
+  - "8"
 before_install:
   - npm install -g npm
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,5 @@ node_js:
   - "6"
   - "7"
   - "8"
-before_install:
-  - npm install -g npm
-before_script:
-  - npm install -g grunt-cli
 matrix:
   fast_finish: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,10 @@ environment:
     - nodejs_version: "0.10"
     - nodejs_version: "0.12"
     - nodejs_version: "4"
+    - nodejs_version: "5"
+    - nodejs_version: "6"
+    - nodejs_version: "7"
+    - nodejs_version: "8"
 platform:
   - x86
   - x64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,8 +16,6 @@ platform:
   - x64
 install:
   - ps: Install-Product node $env:nodejs_version
-  - npm install -g grunt-cli
-  - npm install -g npm
   - npm install
 test_script:
   # Output useful info for debugging.

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ util.namespace = require('getobject');
 // External libs.
 util.hooker = require('hooker');
 util.async = require('async');
-var _ = util._ = require('lodash');
+var _ = util._ = Object.create(require('lodash'));
 var which = require('which').sync;
 // Instead of process.exit. See https://github.com/cowboy/node-exit
 util.exit = require('exit');


### PR DESCRIPTION
Fixes GH-17
Ref https://github.com/gruntjs/grunt-legacy-log/issues/26

This issue was discovered by @axten.

If someone installs the same version of `lodash` that `grunt-legacy-util` uses, npm *could* only install only one copy. Then `grunt-legacy-util` calls `_.mixin(_.str.exports());` adding all the `underscore.string` methods onto `lodash`.

Which means if someone outside of Grunt does:
```js
const _ = require('lodash');
_.truncate('a very long string');
```
It will use the `truncate()` from `underscore.string`!

---

We haven't fully deprecated `grunt.util._` yet though, so Gruntfiles still expect `underscore.string` methods like `grunt.util._.clean()` to exist. So this fix creates our own object for lodash: 
```js
var _ = util._ = Object.create(require('lodash'));
```
This way, the properties we add to lodash only get added to `grunt.util`'s copy.

---

You can test this yourself by creating a Gruntfile:

```js
module.exports = function(grunt) {
  const _ = require('lodash')
  grunt.initConfig({});
  grunt.registerTask('default', function() {
    console.log('from grunt.util', grunt.util._.truncate('truncate this long string'))
    console.log('from lodash', _.truncate('truncate this long string'))
    console.log('on underscore.string but not lodash', grunt.util._.clean('     clean    this    string     '))
  });
};
```

Then `npm install lodash@4.3.0` (the same version `grunt-legacy-util` currently uses). Or just delete the folder `node_modules/grunt-legacy-util/node_modules/lodash` so it uses the top version of `lodash`.

Now your `lodash` outside of Grunt and the `lodash` inside Grunt use the same instance.

![grunt](https://user-images.githubusercontent.com/99604/39319368-b7fb81c6-4935-11e8-8862-2959c751f6af.gif)
