### PR TITLE
Run lodash in context to avoid polluting other lodash.

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,8 @@ util.namespace = require('getobject');
 // External libs.
 util.hooker = require('hooker');
 util.async = require('async');
-var _ = util._ = Object.create(require('lodash'));
+// Dont pollute other lodash: https://github.com/gruntjs/grunt-legacy-util/issues/17
+var _ = util._ = require('lodash').runInContext();
 var which = require('which').sync;
 // Instead of process.exit. See https://github.com/cowboy/node-exit
 util.exit = require('exit');


### PR DESCRIPTION
Fixes GH-17

The `Object.create` solution I implemented https://github.com/gruntjs/grunt-legacy-util/pull/18 wasn't a good one. As it breaks calling the lodash function directly: `grunt.util._()`

Lodash has a function to create our own instance though: [`runInContext`](https://lodash.com/docs/4.17.10#runInContext) which is a better solution and still fixes the original issue so we dont pollute other lodash instances.

![lodash](https://user-images.githubusercontent.com/99604/40323762-475597a8-5ceb-11e8-886a-41fecdd06a5c.gif)
